### PR TITLE
docs: update contributing guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ src/ (~5K LoC)
 
 ## Contributing
 
-We welcome contributions! See our [contributing guide](docs/CONTRIBUTING.md) for details on how to get involved.
+We welcome contributions! See the contributing guidelines for details on how to get involved.
 
 ## License
 


### PR DESCRIPTION
## Summary
- remove broken link to contributing guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_683f525d0684833085c5e5008ded9cc6