### PR TITLE
Fix sample heading typo

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -126,7 +126,7 @@ The system provides several formatted outputs:
 - Some complex semantic queries may require specific technical terminology for best results
 - Search results may sometimes be truncated in responses
 
-## Sameple Inputs/Outputs
+## Sample Inputs/Outputs
 
 ### CLI
 


### PR DESCRIPTION
## Summary
- fix simple typo in `DEMO.md` sample section heading

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src', ModuleNotFoundError: No module named 'numpy', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_683f525aa6208330a4aaf50e18c74950